### PR TITLE
Get the OS and Version for iOS 12.2 sims. Fixes #456

### DIFF
--- a/src/main/java/com/github/device/Device.java
+++ b/src/main/java/com/github/device/Device.java
@@ -46,13 +46,27 @@ public class Device {
         this.state = deviceJson.getString("state");
         this.isAvailable = deviceJson.getString("availability").equals("(available)");
         this.deviceType = deviceType;
+        getOSAndVersion(deviceType);
+        this.deviceModel = deviceIdentifier.getOrDefault(this.name, "Not Supported");
+        this.deviceManufacturer= "apple";
+    }
+
+    private void getOSAndVersion(String deviceType) {
         String[] osAndVersion = deviceType.split(" ");
         if (osAndVersion.length == 2) {
             this.os = osAndVersion[0];
             this.osVersion = osAndVersion[1];
+        } else {
+            String[] splitDeviceType = deviceType.split("\\.");
+            if (splitDeviceType.length == 5) {
+                osAndVersion = splitDeviceType[splitDeviceType.length - 1].split("-");
+                if (osAndVersion.length == 3) {
+                    this.os = osAndVersion[0];
+                    this.osVersion = osAndVersion[1] + "." + osAndVersion[2];
+                }
+            }
         }
-        this.deviceModel = deviceIdentifier.getOrDefault(this.name, "Not Supported");
-        this.deviceManufacturer= "apple";
+
     }
 
 

--- a/src/test/java/com/github/device/SimulatorTest.java
+++ b/src/test/java/com/github/device/SimulatorTest.java
@@ -163,4 +163,15 @@ public class SimulatorTest {
         simulatorManager.stopScreenRecording();
         Assert.assertTrue(new File(System.getProperty("user.dir") + "/sample.mp4").exists());
     }
+
+    @Test
+    public void getOSandVersionLatest() throws Throwable {
+        simulatorManager = new SimulatorManager();
+        String iOSUDID = simulatorManager.getSimulatorUDID
+                ("iPhone 6s", "12.2", "iOS");
+        Device deviceDetails = simulatorManager.getSimulatorDetailsFromUDID(iOSUDID);
+        assertEquals(deviceDetails.getOsVersion(),"12.2");
+        assertEquals(deviceDetails.getOs(),"iOS");
+    }
+
 }


### PR DESCRIPTION
Get the OS and Version for iOS 12.2 sims. Sample format - `com.apple.CoreSimulator.SimRuntime.iOS-12-2`

Fixes the issue [here](https://github.com/AppiumTestDistribution/AppiumTestDistribution/issues/456) on ATD